### PR TITLE
Add 'remark-autolink-headers` plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,7 @@ module.exports = {
             resolve: `gatsby-transformer-remark`,
             options: {
                 plugins: [
+                    'gatsby-remark-autolink-headers',
                     "gatsby-remark-external-links",
                     "gatsby-remark-prismjs"
                 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8372,6 +8372,53 @@
         }
       }
     },
+    "gatsby-remark-autolink-headers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-4.0.0.tgz",
+      "integrity": "sha512-HL0Z959MkX7ZNC9WsDZjPo3zj0vCoWW03x0x0OOkAwqbHFZLIYoD+PDEQeT7AeRdDPOO3Ve5AUn3R+o/wnVZXQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        },
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
+        },
+        "unist-util-visit": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+          "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^4.0.0",
+            "unist-util-visit-parents": "^3.0.0"
+          }
+        }
+      }
+    },
     "gatsby-remark-external-links": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gatsby": "^2.13.3",
     "gatsby-plugin-emotion": "^4.1.0",
     "gatsby-plugin-react-helmet": "^3.1.5",
+    "gatsby-remark-autolink-headers": "^4.0.0",
     "gatsby-remark-external-links": "0.0.4",
     "gatsby-remark-prismjs": "^3.4.5",
     "gatsby-source-filesystem": "^2.1.9",


### PR DESCRIPTION
The following commit adds the `gatsby-autolink-headers` plugin in order to automatically create anchor links in markdown content which can be later used to reference individual sections of the documentation.

- https://www.gatsbyjs.com/plugins/gatsby-remark-autolink-headers/

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>