### PR TITLE
Fix 129: fix plugins typedoc link

### DIFF
--- a/src/docs/authoring_plugins.md
+++ b/src/docs/authoring_plugins.md
@@ -194,7 +194,7 @@ Then you'll only have to refresh the tab of the `Development Host` instance, the
 Note: you may use watch mode as well.
 
 ## API of plug-ins
-[Browse typedoc of plug-ins](https://eclipse-theia.github.io/theia/docs/next/modules/plugin.__theia_plugin_-1.html)
+[Browse typedoc of plug-ins](https://eclipse-theia.github.io/theia/docs/next/modules/plugin._plugin_-1.html)
 
 ## VS Code implementation
 Theia is providing VS Code API. Check the following link to get the current status of what is implemented.


### PR DESCRIPTION
**What it does**

Fixes: #129

The following commit fixes the typedoc link for the `plugins`.

**How to test**

- confirm that the link works in the preview
  - navigate to "_Authoring Pugins_"
  - click the "_Browse typedoc of plug-ins"_ link

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>