### PR TITLE
Check for Updates gives no feedback if there is none [macOS]

### DIFF
--- a/src/docs/blueprint_documentation.md
+++ b/src/docs/blueprint_documentation.md
@@ -28,7 +28,7 @@ You can also directly run the unpackaged application, e.g. to test it during dev
 With `yarn electron package`, you package the application into an executable file for your current operating system.
 The packaged application will be located in `applications/electron/dist`.
 The folder `applications/electron/dist/<OS>-unpackaged` will contain the files that are bundled into the final packaged executable.
-For Linux, this is an executable `.AppImage`, for Windows a `.exe` installer, and a `.pkg` installer for macOS.
+For Linux, this is an executable `.AppImage`, for Windows a `.exe` installer, and a `.dmg` disk image for macOS.
 
 You can also just create the unpackaged content by running `yarn electron package:preview`.
 This is useful to see the bundled files and saves time compared to a full package.

--- a/src/docs/blueprint_download.md
+++ b/src/docs/blueprint_download.md
@@ -30,7 +30,7 @@ Eclipse Theia Blueprint is ***not*** **a production-ready product**. Therefore, 
     <tr>
       <td><a href="https://www.eclipse.org/downloads/download.php?file=/theia/latest/windows/TheiaBlueprint.exe&r=1" download>Download latest</a></td>
       <td><a href="https://www.eclipse.org/downloads/download.php?file=/theia/latest/linux/TheiaBlueprint.AppImage&r=1" download>Download latest</a></td>
-      <td><a href="https://www.eclipse.org/downloads/download.php?file=/theia/latest/macos/TheiaBlueprint.pkg&r=1" download>Download latest</a></td>
+      <td><a href="https://www.eclipse.org/downloads/download.php?file=/theia/latest/macos/TheiaBlueprint.dmg&r=1" download>Download latest</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
* switch mac target from pkg to dmg, because this allows auto-update

-> Website needs to be updated after https://github.com/eclipse-theia/theia-blueprint/pull/94 was merged and the dmg was published for the first itme