### PR TITLE
Consistent heading margin

### DIFF
--- a/src/components/index/Banner.js
+++ b/src/components/index/Banner.js
@@ -67,12 +67,11 @@ const StyledBanner = styled.div`
         }
 
         h3 {
-            margin-bottom: 2rem;
             @media(max-width: ${breakpoints.md}) {
                 width: 100%;
                 max-width: 60rem;
-                margin: 0 auto;
-                margin-bottom: 2rem;
+                margin-left: auto;
+                margin-right: auto;
                 text-align: center;
             }
         }

--- a/src/components/index/Feature.js
+++ b/src/components/index/Feature.js
@@ -36,7 +36,7 @@ const StyledFeature = styled.div`
     }
 
     h3 {
-        margin: 2rem 0 3rem;
+        margin-top: 2rem;
     }
 
     & > p {

--- a/src/components/index/Header.js
+++ b/src/components/index/Header.js
@@ -91,7 +91,7 @@ const Header = () => (
                     <h1 className="heading-primary">
                     An Open, Flexible and Extensible Cloud & Desktop IDE Platform
                     </h1>
-                    <h2 className="heading-tertiary" style={{ fontSize: '2.2rem' }}>
+                    <h2 style={{ fontSize: '2.2rem' }}>
                         Eclipse Theia helps you efficiently develop and deliver multi-language Cloud & Desktop IDEs and tools with modern, state-of-the-art web technologies.
                         <br/>
                         <a href="https://dev.to/svenefftinge/theia-1-0-finally-a-good-browser-ide-3ok0" rel="noopener noreferrer">Learn about the 1.0 Release!</a>

--- a/src/components/index/Promo.js
+++ b/src/components/index/Promo.js
@@ -78,10 +78,6 @@ const StyledPromo = styled.div`
     .promo__video {
         width: 100%;
     }
-
-    p {
-        margin-top: 3rem;
-    }
 `
 
 const Promo = ({ 

--- a/src/layouts/layout.js
+++ b/src/layouts/layout.js
@@ -97,6 +97,7 @@ const Layout = ({ children, canonical }) => {
 
                 .heading-tertiary {
                     font-size: 2.5rem;
+                    margin-bottom: 1.5rem;
                 }
 
                 /* --------------------------------------------- */


### PR DESCRIPTION
- Remove different file-based margin-bottom rules for headings and add to .heading-tertiary

Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>