### PR TITLE
Added support section to Theia Blueprint documentation

### DIFF
--- a/src/docs/blueprint_download.md
+++ b/src/docs/blueprint_download.md
@@ -47,3 +47,7 @@ The source code for Eclipse Theia Blueprint is available on [Github](https://git
 ## Documentation
 
 Please see [here](/docs/blueprint_documentation) for documentation on how to customize Eclipse Theia Blueprint.
+
+## Support
+
+Need help with Theia? To get support by the community go to the [Discourse Theia forum](https://community.theia-ide.org/) or the [Discussions at Github](https://github.com/eclipse-theia/theia/discussions). To get professional support for Theia see the [support page](/support/). 


### PR DESCRIPTION
Adds a section to the Blueprint documentation with links to the forums and to the support page.

Signed-off-by: Maximilian Koegel <mkoegel@eclipsesource.com>