### PR TITLE
Fix nested bullet list in documentation

### DIFF
--- a/src/layouts/docs-layout.js
+++ b/src/layouts/docs-layout.js
@@ -85,6 +85,10 @@ const DocContainer = styled.div`
         margin-top: .8rem;
     }
 
+    li > p {
+        display: inline;
+    }
+
     code,
     pre {
         max-width: 100%;


### PR DESCRIPTION
- Add css-rule to display incorrectly added <p>-tag inline.
fixes #221
The problem here is, that when transforming md to html text is wrapped in paragraphs and only tight lists are unrolled. <p> is a block element and therefore wraps to the newline.


Signed-off-by: Max Elia Schweigkofler <max_elia@hotmail.de>