### PR TITLE
docs: Bind `LocalizationContribution` in the backend

### DIFF
--- a/src/docs/i18n.md
+++ b/src/docs/i18n.md
@@ -75,7 +75,7 @@ export class CustomLocalizationContribution implements LocalizationContribution 
 }
 ```
 
-Lastly, this `LocalizationContribution` will have to be bound within your frontend injection module:
+Lastly, this `LocalizationContribution` will have to be bound within your backend injection module:
 
 ```typescript
 bind(CustomLocalizationContribution).toSelf().inSingletonScope();


### PR DESCRIPTION
Fixes an error in the documentation, noticed due to https://github.com/eclipse-theia/theia/discussions/10637.