### PR TITLE
Update TypeFox support link

### DIFF
--- a/src/components/Support.js
+++ b/src/components/Support.js
@@ -121,7 +121,7 @@ const supporters = [
         img: TypeFoxLogo,
         title: 'TypeFox',
         link: 'https://typefox.io',
-        support: 'https://www.typefox.io/theia/',
+        support: 'https://www.typefox.io/cloud-and-desktop-ides/',
         training: 'https://www.typefox.io/trainings/'
     }
 ]


### PR DESCRIPTION
We've updated the structure of our website. Although the previous link still works (the user is redirected), updating is a good idea nonetheless.