### PR TITLE
Document how to change default locale

### DIFF
--- a/src/docs/i18n.md
+++ b/src/docs/i18n.md
@@ -7,7 +7,7 @@ title: Internationalization
 Theia can be localized by installing [Visual Studio Code language packs](https://code.visualstudio.com/docs/getstarted/locales). Using the `Configure Display Language` command, users of Theia can change their currently used locale.
 The framework provides additional features to enable extension developers to localize their own extensions.
 
-## Localizing your extension
+## Localizing Your Extension
 
 Let's say you have a simple string you want to present in the frontend of your application, like a custom widget that displays a goodbye message:
 
@@ -83,3 +83,21 @@ bind(LocalizationContribution).toService(CustomLocalizationContribution);
 ```
 
 Be aware that the `Configure Display Language` command only shows a locale once its language pack has been installed. This assures that no parts of the Theia base framework remain untranslated after a user changes the display language.
+
+## Changing the Default Locale
+
+If you want to deploy your Theia app to a specific region, you may want to change the default locale.
+To do this you simply add a `defaultLocale` entry to the frontend configuration of your Theia app in your `package.json` file:
+
+```json
+"theia": {
+    "frontend": {
+        "config": {
+            "defaultLocale": "zh-cn"
+        }
+    }
+}
+```
+
+The first time a user starts your Theia app, the locale will be automatically set to the selected default locale.
+They are still free to change the selected locale using the `Configure Display Language` command.


### PR DESCRIPTION
Since a lot of questions came in recently on the discourse forum regarding default locales, I decided to write a short section on that.

Also changes a headline to use the correct header capitalization.