### PR TITLE
Prevent layout shifting of landing page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fetch = require('node-fetch')
 
 exports.onCreateNode = ({ node, actions }) => {
     const { createNodeField } = actions
@@ -12,7 +13,36 @@ exports.onCreateNode = ({ node, actions }) => {
             value: slug
         })
     }
-} 
+}
+
+exports.onCreatePage = async ({ page, reporter, actions }) => {
+    if (page.path === '/') {
+        try {
+            const response = await fetch(
+                'https://api.eclipse.org/adopters/projects/ecd.theia', {
+                    method: 'GET',
+                    headers: {
+                        accept: 'application/json',
+                    }
+                })
+            const responseJson = await response.json()
+            const adopters = responseJson[0].adopters
+            actions.deletePage(page)
+            actions.createPage({
+                ...page,
+                context: {
+                    ...page.context,
+                    adopters,
+                },
+            })
+        } catch (error) {
+            reporter.panic(
+                'Failed to fetch Theia Adopters from "api.eclipse.org"',
+                error
+            )
+        }
+    }
+}
 
 exports.createPages = async ({ graphql, reporter, actions }) => {
     const { createPage } = actions

--- a/package-lock.json
+++ b/package-lock.json
@@ -5219,6 +5219,13 @@
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha512-IHLHYskTc2arMYsHZH82PVX8CSKT5lzb7AXeyO06QnjGDKtkv+pv3mEki6S7reB/x1QPo+YPxQRNEVgR5V/w3Q=="
+        }
       }
     },
     "cross-spawn": {
@@ -12116,9 +12123,12 @@
       "integrity": "sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g="
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "node-forge": {
       "version": "0.9.0",
@@ -15372,6 +15382,15 @@
         "inherits": "^2.0.1"
       }
     },
+    "rss-parser": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
+      "integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
+      "requires": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.4.19"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -17027,6 +17046,11 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -18005,6 +18029,11 @@
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw=="
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
     "webpack": {
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
@@ -18498,6 +18527,15 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
     },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -18687,6 +18725,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-remark-prismjs": "^3.4.5",
     "gatsby-source-filesystem": "^2.1.9",
     "gatsby-transformer-remark": "^2.7.5",
+    "node-fetch": "^2.6.7",
     "prismjs": "^1.20.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/components/index/ContributorsAndAdopters.js
+++ b/src/components/index/ContributorsAndAdopters.js
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  ********************************************************************************/
 
-import React, { useState, useEffect } from 'react'
+import React, { useMemo } from 'react'
 
 import styled from '@emotion/styled'
 import { contributorsAndAdopters } from '../../utils/data'
@@ -85,31 +85,12 @@ const Styled = styled.div`
     }
 `
 
-const ContributorsAndAdopters = () => {
-
-    const [adopters, setAdopters] = useState(contributorsAndAdopters);
-
-    useEffect(() => {
-        const fetchAdopters = async () => {
-            const response = await fetch('https://api.eclipse.org/adopters/projects/ecd.theia', {
-                method: 'GET',
-                headers: {
-                  accept: 'application/json',
-                }
-            });
-            const json = await response.json();
-            let newAdopters = json[0].adopters.concat(adopters);
-            newAdopters.sort((a,b) => {
-                if (a.name.toUpperCase() < b.name.toUpperCase())
-                    return -1
-                else
-                    return 1
-            })
-            setAdopters(newAdopters);
-        }
-        fetchAdopters();
-    }, []);
-    
+const ContributorsAndAdopters = ({ adopters }) => {
+    const allAdopters = useMemo(() => {
+        const result = [...contributorsAndAdopters, ...adopters]
+        result.sort((a,b) => a.name.toUpperCase() < b.name.toUpperCase() ? -1 : 1)
+        return result
+    }, [adopters])
     return (
         <div className="row">
             <Styled>
@@ -117,7 +98,7 @@ const ContributorsAndAdopters = () => {
                     <h3 className="heading-tertiary">Contributors & Adopters</h3>
                     <div className="contributors__images">
                         {
-                            adopters.map((item, i) => (
+                            allAdopters.map((item, i) => (
                                 <div key={i} className="contributors__image-container">
                                     <a target="_blank" rel="noopener noreferrer" href={item.homepage_url}>
                                         <img className="contributors__image" src={(item.src) ? item.src : 'https://api.eclipse.org/adopters/assets/images/adopters/' + item.logo } alt={item.name} />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,14 +28,14 @@ import GettingStarted from '../components/index/GettingStarted'
 import IntrosToTheia from '../components/index/IntrosToTheia'
 
 
-export default () => {
+export default ({ pageContext }) => {
     return (
         <Layout canonical='/'>
             <Header />
             <main role="main">
                 <Products />
                 <Features />
-                <ContributorsAndAdopters />
+                <ContributorsAndAdopters adopters={pageContext.adopters}/>
                 <GettingStarted/>
                 <IntrosToTheia />
                 <Banner />


### PR DESCRIPTION
Previously the list of Contributors & Adopters was queried from the Eclipse Foundation
API after the initial rendering of the landing page. Once they were loaded they were
inserted leading to a layout shift. This was especially noticeable when visting the page
via an anchor as the content moved out of the frame.

This is now fixed by determining the list of Contributors & Adopters at build time.
As they are no longer loaded dynamically the layout shift is avoided. Additionally we no
longer need to wait for the API call to finish when visting the website, improving the
load times.

The website needs to be rebuilt whenever the Contributors & Adopters list shall be
updated. Should the API call fail the website build will panic to avoid publishing the
website with an incomplete list.

Contributed on behalf of STMicroelectronics