### PR TITLE
Exclude ms-vscode.js-debug-companion

### DIFF
--- a/src/docs/composing_applications.md
+++ b/src/docs/composing_applications.md
@@ -105,6 +105,7 @@ An example `package.json` may look like the following:
     "vscode-builtin-extensions-pack": "https://open-vsx.org/api/eclipse-theia/builtin-extension-pack/1.50.1/file/eclipse-theia.builtin-extension-pack-1.50.1.vsix"
   },
   "theiaPluginsExcludeIds": [
+    "ms-vscode.js-debug-companion",
     "vscode.extension-editing",
     "vscode.git",
     "vscode.git-ui",


### PR DESCRIPTION
**What it does**

Fixes: https://github.com/eclipse-theia/theia-website/issues/312.
Fixes the tutorial example which does not pass the `download:plugins` script due to an incompatible builtin.