### PR TITLE
Add cdt-gdb-adapter to compatible components

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -106,6 +106,15 @@ const communityReleases = [
                 modules: [
                     {modulename: 'sprotty-theia', url: 'https://www.npmjs.com/package/sprotty-theia/v/0.12.0'}
                 ]
+            },
+            {
+                title: 'Eclipse CDT.cloud Debug Adapter',
+                url: 'https://projects.eclipse.org/projects/ecd.cdt-cloud',
+                version: '0.0.93',
+                modules: [
+                    {modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode/0.0.93'},
+                    {modulename: 'cdt-gdb-adapter', url: 'https://www.npmjs.com/package/cdt-gdb-adapter/v/0.0.16-next.20220930230402.c653a9a.0'}
+                ]
             }
         ]
     }


### PR DESCRIPTION
As requested by @planger on [cdt-cloud-dev](https://www.eclipse.org/lists/cdt-cloud-dev/msg00010.html) here is the entry for cdt-gdb-adapter and related parts of CDT.cloud for Theia 1.29 release.