### PR TITLE
Update try now URL

### DIFF
--- a/src/components/index/GettingStarted.js
+++ b/src/components/index/GettingStarted.js
@@ -43,7 +43,7 @@ const features = [
         img: <img src={TryIt} alt="Try it" />,
         title: "Try it",
         paragraphs: [<>
-        Eclipse Theia is a framework for building tools and IDEs. You can try it by <a href="https://theia-ide.org/docs/composing_applications/">building your own IDE/tools based on Theia</a> within minutes. Alternatively, you can <a href="https://theia-ide.org/docs/blueprint_download/">download and try Theia Blueprint</a>, a template tool based on Eclipse Theia or <a href="https://theia.cloud.34.141.62.32.nip.io/">try it online</a>.
+        Eclipse Theia is a framework for building tools and IDEs. You can try it by <a href="https://theia-ide.org/docs/composing_applications/">building your own IDE/tools based on Theia</a> within minutes. Alternatively, you can <a href="https://theia-ide.org/docs/blueprint_download/">download and try Theia Blueprint</a>, a template tool based on Eclipse Theia or <a href="https://try.theia-cloud.io/">try it online</a>.
         </>]
     },
     {

--- a/src/components/index/Header.js
+++ b/src/components/index/Header.js
@@ -115,7 +115,7 @@ const Header = () => (
                 </h2>
                 <div className="header__buttons">
                         <a className="btn" href="https://github.com/eclipse-theia/theia" target="_blank" rel="noopener noreferrer">View on GitHub</a>
-                        <a className="btn btn--cta" href="https://theia.cloud.34.141.62.32.nip.io/" rel="noopener">Try online &nbsp;&nbsp;&rarr;</a>
+                        <a className="btn btn--cta" href="https://try.theia-cloud.io/" rel="noopener">Try online &nbsp;&nbsp;&rarr;</a>
                         <a className="btn btn--cta" href="/docs/blueprint_download/" rel="noopener">Try on desktop &nbsp;&nbsp;&rarr;</a>
                  </div>
                 </div>

--- a/src/docs/blueprint_download.md
+++ b/src/docs/blueprint_download.md
@@ -37,7 +37,7 @@ NOTE: Eclipse Theia Blueprint is currently in beta. While we are continuing to m
 
 ## Try Theia Blueprint Online
 
-You can also [try the latest version of Theia Blueprint online](https://theia.cloud.34.141.62.32.nip.io/). The online test version is limited to 30 minutes per session and hosted via [Theia.cloud](https://github.com/eclipsesource/theia-cloud).
+You can also [try the latest version of Theia Blueprint online](https://try.theia-cloud.io/). The online test version is limited to 30 minutes per session and hosted via [Theia.cloud](https://github.com/eclipsesource/theia-cloud).
 
 ## Reporting Feature Requests and Bugs
 


### PR DESCRIPTION
Update the try now url to the proper URL try.theia-cloud.io

**Note:** This depends on changes to the Try Now cluster deployment. Consequently, merging this should be coordinated with @jfaltermeier to avoid downtimes of the Try Now button