### PR TITLE
Update compatible technologies with EMF.cloud modules for CR 1.45.1

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -91,8 +91,10 @@ const communityReleases = [
             {
                 title: 'Eclipse EMF.cloud',
                 url: 'https://www.eclipse.dev/emfcloud/',
-                version: 'TBD',
-                modules: []
+                version: '0.8.0-theia-cr03',
+                modules: [
+                    { modulename: '@eclipse-emfcloud/jsonforms-property-view', url: 'https://www.npmjs.com/package/@eclipse-emfcloud/jsonforms-property-view/v/0.8.0-theia-cr03' }
+                ]
             },
             {
                 title: 'Eclipse Sprotty',


### PR DESCRIPTION
Add `@eclipse-emfcloud/jsonforms-property-view` module versions to compatible technologies section