### PR TITLE
Fixed broken documentation link in getting_started.md

### DIFF
--- a/src/docs/getting_started.md
+++ b/src/docs/getting_started.md
@@ -5,7 +5,7 @@ title: Getting Started
 # Getting started
 
 In this section, we provide a high level overview on how to get started with Eclipse Theia and link to respective sections to read.
-Eclipse Theia is a platform for building custom Cloud & Desktop IDEs and tools with modern web technologies. The Eclipse Theia Platform is not a tool itself, but there are many tools which are built upon Theia. The Theia project provides a tool called [Eclipse Theia IDE](/#theiaide) that can be directly used. The Theia IDE can also be [used as a template](http://localhost:8000/docs/blueprint_documentation/) to get started with building your own tool. Please have a look at the project goals for more details!
+Eclipse Theia is a platform for building custom Cloud & Desktop IDEs and tools with modern web technologies. The Eclipse Theia Platform is not a tool itself, but there are many tools which are built upon Theia. The Theia project provides a tool called [Eclipse Theia IDE](/#theiaide) that can be directly used. The Theia IDE can also be [used as a template](https://theia-ide.org/docs/blueprint_documentation/) to get started with building your own tool. Please have a look at the project goals for more details!
 
 ## Use Eclipse Theia (IDE)
 


### PR DESCRIPTION
This hyperlink failed to use the theia-ide.org domain to be reachable on the internet.