### PR TITLE
Remove path prefix in prep for DNS switch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build website
         run: |
           npm install
-          PATH_PREFIX="theia-website" npm run build -- --prefix-paths
+          npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
         with:


### PR DESCRIPTION
As soon as we switch over to theia-ide.org, we are not running under a subdirectory anymore (`/theia-website`). So we need to remove the path prefix before switching over the DNS. Until the final switch (which I've already triggered via the EF), the website links won't work. But that's fine as they should start working again as soon as theia-ide.org points to the GH page.