### PR TITLE
Fix link issues after hard-reloading pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ npm run serve
 
 ## CI
 
-The website is automatically built at and deployed to Netlify.
-A preview of each PR is deployed to Netlify.
+The website is automatically built with [Github workflows](.github/workflows/) and deployed on Github pages, which are reachable via [theia-ide.org](https://theia-ide.org/).
 
-In addition, every commit on `master` is built and published to branch `gh-pages`, which will soon replace the deployment of Netlify.
-A preview of every pull request is published at [eclipse-theia/theia-website-previews](https://github.com/eclipse-theia/theia-website-previews).
+A preview of every pull request is published at [eclipse-theia/theia-website-previews](https://github.com/eclipse-theia/theia-website-previews). You'll see a comment with the link to the preview once the build is finished.
 For more information, see [`publish.yml`](.github/workflows/publish.yml) and [`preview.yml`](.github/workflows/preview.yml).
 
 ## License

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,7 +20,8 @@ module.exports = {
                 plugins: [
                     'gatsby-remark-autolink-headers',
                     "gatsby-remark-external-links",
-                    "gatsby-remark-prismjs"
+                    "gatsby-remark-prismjs",
+                    "gatsby-plugin-catch-links"
                 ]
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-helmet": "^5.0.9",
         "env-cmd": "^10.0.1",
         "gatsby": "^2.13.3",
+        "gatsby-plugin-catch-links": "^2.10.0",
         "gatsby-plugin-emotion": "^4.1.0",
         "gatsby-plugin-react-helmet": "^3.1.5",
         "gatsby-remark-autolink-headers": "^4.0.0",
@@ -1271,11 +1272,14 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/runtime-corejs3": {
@@ -1286,6 +1290,11 @@
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/standalone": {
       "version": "7.10.2",
@@ -9882,6 +9891,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gatsby-plugin-catch-links": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.10.0.tgz",
+      "integrity": "sha512-r+YBR6ChWOwb0VygrjtS6nrz0fv5KyZiyL0aa/6Na4st4D+PHqml2nuYtLx0+otxjscSjJXk+7eg04YDGEeFng==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^2.0.0"
+      }
+    },
     "node_modules/gatsby-plugin-emotion": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.3.4.tgz",
@@ -10304,14 +10328,6 @@
         "gatsby": "^3.0.0-next.0",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
-      }
-    },
-    "node_modules/gatsby-remark-autolink-headers/node_modules/@babel/runtime": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/gatsby-remark-autolink-headers/node_modules/lodash": {
@@ -24651,11 +24667,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
+      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/runtime-corejs3": {
@@ -25578,8 +25601,7 @@
     "@mdx-js/react": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.5.tgz",
-      "integrity": "sha512-y1Yu9baw3KokFrs7g5RxHpJNSU4e1zk/5bAJX94yVATglG5HyAL0lYMySU8YzebXNE+fJJMCx9CuiQHy2ezoew==",
-      "requires": {}
+      "integrity": "sha512-y1Yu9baw3KokFrs7g5RxHpJNSU4e1zk/5bAJX94yVATglG5HyAL0lYMySU8YzebXNE+fJJMCx9CuiQHy2ezoew=="
     },
     "@mdx-js/runtime": {
       "version": "1.6.5",
@@ -26558,14 +26580,12 @@
     "acorn-dynamic-import": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "requires": {}
+      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
     },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-      "requires": {}
+      "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
     },
     "address": {
       "version": "1.1.2",
@@ -26617,14 +26637,12 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "requires": {}
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
     },
     "ajv-keywords": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-      "requires": {}
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -27074,8 +27092,7 @@
     "babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "requires": {}
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -27207,8 +27224,7 @@
     "babel-plugin-remove-graphql-queries": {
       "version": "2.9.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.9.5.tgz",
-      "integrity": "sha512-z0T2dMz6V8a8hC11NFDwnuT5xR0k4Vu4Zie4A5BPchQOe59uHpbaM54mMl66FUA/iLTfYC11xez1N3Wc1gV20w==",
-      "requires": {}
+      "integrity": "sha512-z0T2dMz6V8a8hC11NFDwnuT5xR0k4Vu4Zie4A5BPchQOe59uHpbaM54mMl66FUA/iLTfYC11xez1N3Wc1gV20w=="
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -29895,8 +29911,7 @@
         "ws": {
           "version": "7.3.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
-          "requires": {}
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
         }
       }
     },
@@ -30463,8 +30478,7 @@
     "eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
-      "requires": {}
+      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
     },
     "eslint-scope": {
       "version": "5.1.0",
@@ -31750,6 +31764,15 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-catch-links": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.10.0.tgz",
+      "integrity": "sha512-r+YBR6ChWOwb0VygrjtS6nrz0fv5KyZiyL0aa/6Na4st4D+PHqml2nuYtLx0+otxjscSjJXk+7eg04YDGEeFng==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "gatsby-plugin-emotion": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.3.4.tgz",
@@ -32039,8 +32062,7 @@
         "ws": {
           "version": "7.3.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
-          "requires": {}
+          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w=="
         }
       }
     },
@@ -32056,14 +32078,6 @@
         "unist-util-visit": "^2.0.3"
       },
       "dependencies": {
-        "@babel/runtime": {
-          "version": "7.13.10",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
-          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
         "lodash": {
           "version": "4.17.21",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -32910,8 +32924,7 @@
         "graphql-type-json": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
-          "requires": {}
+          "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
         }
       }
     },
@@ -32993,8 +33006,7 @@
     "graphql-type-json": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
-      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==",
-      "requires": {}
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
     },
     "gray-matter": {
       "version": "4.0.2",
@@ -38102,8 +38114,7 @@
     "react-side-effect": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz",
-      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==",
-      "requires": {}
+      "integrity": "sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg=="
     },
     "react-style-singleton": {
       "version": "2.1.0",
@@ -38140,8 +38151,7 @@
     "react-tweet-embed": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/react-tweet-embed/-/react-tweet-embed-1.2.2.tgz",
-      "integrity": "sha512-Y932BlSaJsDUsKDucC2opzzd+uhc0YNhrlTa/4Beb2be1od+AjLGo6Fhuo2wPT0D+fF4VTXOyoZyA8Yc88RdYA==",
-      "requires": {}
+      "integrity": "sha512-Y932BlSaJsDUsKDucC2opzzd+uhc0YNhrlTa/4Beb2be1od+AjLGo6Fhuo2wPT0D+fF4VTXOyoZyA8Yc88RdYA=="
     },
     "react-twitter-embed": {
       "version": "2.0.8",
@@ -38157,8 +38167,7 @@
     "reactjs-popup": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/reactjs-popup/-/reactjs-popup-2.0.5.tgz",
-      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==",
-      "requires": {}
+      "integrity": "sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA=="
     },
     "read": {
       "version": "1.0.7",
@@ -41485,8 +41494,7 @@
     "use-callback-ref": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
-      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==",
-      "requires": {}
+      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
     },
     "use-sidecar": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gatsby-remark-prismjs": "^3.4.5",
     "gatsby-source-filesystem": "^2.1.9",
     "gatsby-transformer-remark": "^2.7.5",
+    "gatsby-plugin-catch-links": "^2.10.0",
     "node-fetch": "^2.6.7",
     "prismjs": "^1.20.0",
     "react": "^16.8.6",

--- a/src/docs/authoring_extensions.md
+++ b/src/docs/authoring_extensions.md
@@ -4,7 +4,7 @@ title: Authoring an Extension
 
 # Authoring Theia Extensions
 
-This guide will walk you through the process of creating Theia extensions and deploying them in your Theia-based application. Please make sure to be aware of the [different available extension mechanisms](../extensions/) of Theia (Plugins vs. Extensions) before you continue reading.
+This guide will walk you through the process of creating Theia extensions and deploying them in your Theia-based application. Please make sure to be aware of the [different available extension mechanisms](/docs/extensions/) of Theia (Plugins vs. Extensions) before you continue reading.
 
 As an example, we are going to add a menu item _Say hello_ that displays a notification "Hello world!". This article is guiding you through all the necessary steps.
 
@@ -14,7 +14,7 @@ A Theia app is composed of so-called _extensions_. An extension provides a set o
 
 Theia defines a plethora of contribution interfaces that allow extensions to add their behaviour to various aspects of the application. Just search for interfaces with the name `*Contribution` to get an idea. An extension implements the contribution interfaces belonging to the functionality it wants to deliver. In this example, we are going to implement a `CommandContribution` and a `MenuContribution`. Other ways for extensions to interact with a Theia application are via one of the various _services_ or _managers_.
 
-In Theia, everything is wired up via [dependency injection](../services_and_contributions#dependency-injection-di). An extension defines one or more dependency injection modules. This is where it binds its contribution implementations to the respective contribution interface. The modules are listed in the `package.json` of the extension package. An extension can contribute to the frontend, e.g. providing a UI extension, as well as to the backend, e.g. contributing a language server. When the application starts, the union of all these modules is used to configure a single, global dependency injection container on each, the frontend and the backend. The runtime will then collect all contributions of a specific kind by means of a multi-inject.
+In Theia, everything is wired up via [dependency injection](/docs/services_and_contributions#dependency-injection-di). An extension defines one or more dependency injection modules. This is where it binds its contribution implementations to the respective contribution interface. The modules are listed in the `package.json` of the extension package. An extension can contribute to the frontend, e.g. providing a UI extension, as well as to the backend, e.g. contributing a language server. When the application starts, the union of all these modules is used to configure a single, global dependency injection container on each, the frontend and the backend. The runtime will then collect all contributions of a specific kind by means of a multi-inject.
 
 ## Prerequisites
 

--- a/src/docs/authoring_plugins.md
+++ b/src/docs/authoring_plugins.md
@@ -4,7 +4,7 @@ title: Authoring Plug-ins
 
 # Authoring Theia Plug-ins
 
-This documentation is deprecated and needs to be updated. We currently recommend using VS Code extensions or Theia extensions instead of Theia Plugins. See the [extension overview](../extensions/) for more details.
+This documentation is deprecated and needs to be updated. We currently recommend using VS Code extensions or Theia extensions instead of Theia Plugins. See the [extension overview](/docs/extensions/) for more details.
 <!--
 Let's create our first Theia plug-in. As an example, we are going to register a command _Hello World_ that displays a notification "Hello world!". This article is guiding you through all the necessary steps.
 

--- a/src/docs/authoring_vscode_extensions.md
+++ b/src/docs/authoring_vscode_extensions.md
@@ -4,13 +4,13 @@ title: Authoring VS Code Extensions
 
 # Authoring VS Code Extensions
 
-Alongside [Theia extensions](../extensions#theia-extensions), VS Code extensions can also be used to enhance Theia applications with additional functionality, such as language support, commands, or tree views.
+Alongside [Theia extensions](/docs/extensions#theia-extensions), VS Code extensions can also be used to enhance Theia applications with additional functionality, such as language support, commands, or tree views.
 VS Code extensions contribute functionality through the dedicated VS Code API, which the Theia framework also supports.
 This means that extensions that have been developed for VS Code are also compatible with Theia, and vice versa.
 The [coverage report](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) provides more details on the extent to which the VS Code API is supported by each Theia version.
 
 While there are certain overlaps in which types of functionality can be contributed to a Theia application with a Theia extension or a VS Code extension, both have their unique advantages and disadvantages.
-Please refer to the overview on [extensions and plugins](../extensions) and an [in-depth comparison](https://eclipsesource.com/blogs/2021/03/24/vs-code-extensions-vs-theia-extensions/) for a more detailed discussion.
+Please refer to the overview on [extensions and plugins](/docs/extensions) and an [in-depth comparison](https://eclipsesource.com/blogs/2021/03/24/vs-code-extensions-vs-theia-extensions/) for a more detailed discussion.
 
 In the remainder of this page, we guide you through the process of creating VS Code extensions and deploying them in Theia.
 The steps for deploying VS Code extensions apply not only to VS Code extensions you develop yourself, but also to third-party VS Code extensions from the [Theia marketplace](https://open-vsx.org/). If you use a third-party VS Code extension, you can skip the section "Creating VS Code Extensions" and "Developing VS Code Extensions in a Theia Project".
@@ -129,7 +129,7 @@ Therefore, you need to extend your `package.json` to
 ```
 
 As a result, running `yarn` will download any listed extensions and place them into the folder specified in `theiaPluginsDir` automatically.
-For more details, see also the documentation on [composing Theia applications](../composing_applications/#consuming-vs-code-extensions).
+For more details, see also the documentation on [composing Theia applications](/docs/composing_applications/#consuming-vs-code-extensions).
 
 ### Installing VS Code Extensions at Runtime
 
@@ -160,7 +160,7 @@ To make your VS Code extension available, you'll need to [publish](https://githu
 ## Developing VS Code Extensions in a Theia Project
 
 In certain scenarios, you may not want to develop your VS Code extension in isolation from your Theia application, but instead you may prefer to develop both your extensions and your application in project to keep update cycles short and immediate.
-This is particularly useful if you develop your extensions primarily to be part a specific Theia application, thus you want to develop, test and debug them directly in the context of your Theia app, potentially alongside other [Theia extensions](../extensions#theia-extensions).
+This is particularly useful if you develop your extensions primarily to be part a specific Theia application, thus you want to develop, test and debug them directly in the context of your Theia app, potentially alongside other [Theia extensions](/docs/extensions#theia-extensions).
 
 In those scenarios, you can also include VS Code extensions as part of your Theia application monorepo.
 While there are several possible configuration options, probably the most straightforward approach is to follow the steps below.

--- a/src/docs/blueprint_documentation.md
+++ b/src/docs/blueprint_documentation.md
@@ -4,9 +4,9 @@ title: Extending/Adopting the Theia IDE
 
 # Extending/Adopting the Theia IDE
 
-This guide provides an overview on how to extend and customize the Theia IDE to your own custom IDE or tool. In this scenario, the Eclipse Theia IDE is an example product used as a reference on how to build desktop IDE-like products based on the Eclipse Theia framework. If you just want to use the Theia IDE, see the [user guide](../user_getting_started)
+This guide provides an overview on how to extend and customize the Theia IDE to your own custom IDE or tool. In this scenario, the Eclipse Theia IDE is an example product used as a reference on how to build desktop IDE-like products based on the Eclipse Theia framework. If you just want to use the Theia IDE, see the [user guide](/docs/user_getting_started)
 
-Please note that adopting the Theia IDE as a basis is just one of several ways to get started with building a Theia-based application. We recommend reading the article "[Build your own IDE/Tool](../composing_applications)" as a first step. Furthermore, this guide is focused on building a desktop app. We also provide an [experimental Docker version](https://github.com/eclipse-theia/theia-blueprint?tab=readme-ov-file#docker-build) of the Theia IDE as an alternative.
+Please note that adopting the Theia IDE as a basis is just one of several ways to get started with building a Theia-based application. We recommend reading the article "[Build your own IDE/Tool](/docs/composing_applications)" as a first step. Furthermore, this guide is focused on building a desktop app. We also provide an [experimental Docker version](https://github.com/eclipse-theia/theia-blueprint?tab=readme-ov-file#docker-build) of the Theia IDE as an alternative.
 
 The Theia IDE assembles a selected subset of existing Theia features and extensions.
 We provide installers for the Theia IDE to be downloaded (see links below).
@@ -57,7 +57,7 @@ However, as signing is highly dependent on your setup, see the [electron builder
 
 ## Adding/Removing Features
 
-The Theia IDE is based on the Theia platform, which is a flexible and adaptable platform for build tools and IDEs. Therefore, you can adapt the feature set and general appearance of the Theia IDE to your custom requirements with almost no limits. The Theia platform provides two mechanism to add your custom extensions: VS Code extensions and Theia extensions. Please have a look at the [overview about Theia extension capabilities](../extensions/) for details. When assembling a product such as the Theia IDE, you can freely decide, which VS Code extensions and Theia extensions are part of it and thereby influence the feature set of your custom product. The following two sections describe how to modify which [VS Code Extensions](#updating-bundled-vs-code-extensions) and which [Theia extensions](#customizing-theia-extensions) are part of your product. Please also note that you can allow users of a Theia-based tool to [install VS Code extensions at runtime](../user_install_vscode_extensions/).
+The Theia IDE is based on the Theia platform, which is a flexible and adaptable platform for build tools and IDEs. Therefore, you can adapt the feature set and general appearance of the Theia IDE to your custom requirements with almost no limits. The Theia platform provides two mechanism to add your custom extensions: VS Code extensions and Theia extensions. Please have a look at the [overview about Theia extension capabilities](/docs/extensions/) for details. When assembling a product such as the Theia IDE, you can freely decide, which VS Code extensions and Theia extensions are part of it and thereby influence the feature set of your custom product. The following two sections describe how to modify which [VS Code Extensions](#updating-bundled-vs-code-extensions) and which [Theia extensions](#customizing-theia-extensions) are part of your product. Please also note that you can allow users of a Theia-based tool to [install VS Code extensions at runtime](/docs/user_install_vscode_extensions/).
 
 ## Updating Bundled VS Code Extensions
 
@@ -161,7 +161,7 @@ To use another custom dialog widget, remove this code, extend Theia’s AboutDia
 
 ### Customizing the Preferences
 
-The default preferences directory in Eclipse Theia IDE is `.theia-blueprint` and is located as described in the [Preferences documentation](../preferences/). You can customize this location by modifying [`theia-blueprint-variables-server.ts`](https://github.com/eclipse-theia/theia-blueprint/blob/master/theia-extensions/theia-blueprint-product/src/node/theia-blueprint-variables-server.ts).
+The default preferences directory in Eclipse Theia IDE is `.theia-blueprint` and is located as described in the [Preferences documentation](/docs/preferences/). You can customize this location by modifying [`theia-blueprint-variables-server.ts`](https://github.com/eclipse-theia/theia-blueprint/blob/master/theia-extensions/theia-blueprint-product/src/node/theia-blueprint-variables-server.ts).
 
 ### Customizing the Installer
 

--- a/src/docs/commands_keybindings.md
+++ b/src/docs/commands_keybindings.md
@@ -8,7 +8,7 @@ Commands are runnable actions defined by an ID and the function to be executed (
 
 The following sections provide details about how to contribute commands, keybindings and menu items. The sections will describe how to connect the different contributions and how to use the corresponding services for managing these items.
 
-If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](../services_and_contributions/).
+If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](/docs/services_and_contributions/).
 
 All the following code examples are from the [Theia extension generator](https://github.com/eclipse-theia/generator-theia-extension). You can get the same code set-up by installing the generator, selecting the “Hello World” example (see here) and choosing “helloworld” as the name.
 
@@ -50,7 +50,7 @@ Finally, by implementing `isToggle` a handler can optionally specify, whether me
 
 ### Binding the contribution to CommandContribution
 
-To make our `CommandContribution` accessible to Theia, we need to bind the custom `HelloworldCommandContribution` to the respective contribution symbol `CommandContribution`. This is done in the `helloworld-frontend-module`, for more details see [Services and Contributions](../services_and_contributions/).
+To make our `CommandContribution` accessible to Theia, we need to bind the custom `HelloworldCommandContribution` to the respective contribution symbol `CommandContribution`. This is done in the `helloworld-frontend-module`, for more details see [Services and Contributions](/docs/services_and_contributions/).
 
 **helloworld-frontend-module.ts**
 
@@ -93,7 +93,7 @@ export class HelloworldMenuContribution implements MenuContribution {
 }
 ```
 
-To make our `MenuContribution` accessible to Theia, we need to bind the custom `HelloWorldMenuContribution` to the respective contribution symbol `MenuContribution`. This is done in the `helloworld-frontend-module`, for more details see [Services and Contributions](../services_and_contributions/).
+To make our `MenuContribution` accessible to Theia, we need to bind the custom `HelloWorldMenuContribution` to the respective contribution symbol `MenuContribution`. This is done in the `helloworld-frontend-module`, for more details see [Services and Contributions](/docs/services_and_contributions/).
 
 **helloworld-contribution.ts**
 

--- a/src/docs/composing_applications.md
+++ b/src/docs/composing_applications.md
@@ -5,11 +5,11 @@ title: Build your own IDE/Tool
 
 # Build your own IDE/Tool
 
-This guide will teach you how to build your own Theia-based application. The guide will demonstrate how to configure your own application composed of existing or new Theia extensions, and any VS Code extensions you want bundled in your application by default. Please get familiar with the [extension mechanisms of Theia](../extensions/) in case you are not already.
+This guide will teach you how to build your own Theia-based application. The guide will demonstrate how to configure your own application composed of existing or new Theia extensions, and any VS Code extensions you want bundled in your application by default. Please get familiar with the [extension mechanisms of Theia](/docs/extensions/) in case you are not already.
 This guide describes the manual steps to build a Theia-based product, there are two ways to avoid this manual set-up:
 
 - [Theia Extension Yeoman generator](https://github.com/eclipse-theia/generator-theia-extension): Generates Theia-based products along with example extensions.
-- [Theia IDE](../../#theiaide): A tool based on the Theia Platform that can be used as a template for creating installable desktop applications based on Theia. [Learn how to extend and adapt the Theia IDE](../blueprint_documentation/).
+- [Theia IDE](/#theiaide): A tool based on the Theia Platform that can be used as a template for creating installable desktop applications based on Theia. [Learn how to extend and adapt the Theia IDE](/docs/blueprint_documentation/).
 
 We still recommend reading the manual guide first, it allows you to understand the structure of a Theia-based project.
 

--- a/src/docs/enhanced_tab_bar_preview.md
+++ b/src/docs/enhanced_tab_bar_preview.md
@@ -4,7 +4,7 @@ title: Enhanced Tab Bar Preview
 
 # Enhanced Tab Bar Preview
 
-By default, Theia shows the value of a widget's `caption` property when users hover above a widget's tab (see also [widgets](../widgets/)).
+By default, Theia shows the value of a widget's `caption` property when users hover above a widget's tab (see also [widgets](/docs/widgets/)).
 In certain use cases, especially with custom editors, this information may however not be sufficient to give users sufficient overview about a widget's content before activating the tab.
 
 Therefore, Theia optionally provides an enhanced tab bar preview for widgets of the main or bottom area of Theia; that is, for horizontal tab bars.

--- a/src/docs/extensions.md
+++ b/src/docs/extensions.md
@@ -29,7 +29,7 @@ Please also note that you can use existing VS Code extensions in Theia, too. A g
 A Theia extension is a module that resides inside a Theia application and directly communicates with other modules (Theia extensions). The Theia project itself is composed of Theia extensions too. To create a Theia application, you can select a number of Theia extensions provided by the Theia project (core extensions), add your own custom Theia extensions and then compile and run the result. Your custom Theia extension will have access to the same API as the core extensions. This modularity allows you to extend, adapt or remove almost anything in Theia according to your requirements. Also, specific use cases, such as complex views are easier to develop with Theia extensions compared to VS Code extensions.
 Technically, an extension is an npm package that exposes any number of DI modules (`ContainerModule`) that contribute to the creation of the DI container.
 Extensions are consumed by declaring them as a `dependency` in the `package.json` of the application/extension, and are installed at compile time.
-See [this section](../authoring_extensions/) for more detail on how to author a Theia extension.
+See [this section](/docs/authoring_extensions/) for more detail on how to author a Theia extension.
 
 ## Theia Plugins
 

--- a/src/docs/getting_started.md
+++ b/src/docs/getting_started.md
@@ -5,21 +5,21 @@ title: Getting Started
 # Getting started
 
 In this section, we provide a high level overview on how to get started with Eclipse Theia and link to respective sections to read.
-Eclipse Theia is a platform for building custom Cloud & Desktop IDEs and tools with modern web technologies. The Eclipse Theia Platform is not a tool itself, but there are many tools which are built upon Theia. The Theia project provides a tool called [Eclipse Theia IDE](../../#theiaide) that can be directly used. The Theia IDE can also be [used as a template](../blueprint_documentation/) to get started with building your own tool. Please have a look at the project goals for more details!
+Eclipse Theia is a platform for building custom Cloud & Desktop IDEs and tools with modern web technologies. The Eclipse Theia Platform is not a tool itself, but there are many tools which are built upon Theia. The Theia project provides a tool called [Eclipse Theia IDE](/#theiaide) that can be directly used. The Theia IDE can also be [used as a template](/docs/blueprint_documentation/) to get started with building your own tool. Please have a look at the project goals for more details!
 
 ## Use Eclipse Theia (IDE)
 
-You cannot directly launch/use Theia as it is a platform. The project provides one tool called [Eclipse IDE](../../#theiaide) that you can directly download and use. Further, it is very easy to [create your own product based on Theia](../composing_applications/). Please also refer to [this article](https://eclipsesource.com/de/blogs/2019/09/25/how-to-launch-eclipse-theia/) highlighting the various options available to [launch/try Eclipse Theia and Theia-based products](https://eclipsesource.com/de/blogs/2019/09/25/how-to-launch-eclipse-theia/).
+You cannot directly launch/use Theia as it is a platform. The project provides one tool called [Eclipse IDE](/#theiaide) that you can directly download and use. Further, it is very easy to [create your own product based on Theia](/docs/composing_applications/). Please also refer to [this article](https://eclipsesource.com/de/blogs/2019/09/25/how-to-launch-eclipse-theia/) highlighting the various options available to [launch/try Eclipse Theia and Theia-based products](https://eclipsesource.com/de/blogs/2019/09/25/how-to-launch-eclipse-theia/).
 
 ## Build a tool or IDE based on Eclipse Theia
 
-The first step is to define a custom product based on Theia. Please check out the guide on [how to build your own IDE or tool based on Theia](../composing_applications/). Subsequently, you might want to extend this product with your own feature for which you can use the [available extension mechanisms of Theia](../extensions/).
+The first step is to define a custom product based on Theia. Please check out the guide on [how to build your own IDE or tool based on Theia](/docs/composing_applications/). Subsequently, you might want to extend this product with your own feature for which you can use the [available extension mechanisms of Theia](/docs/extensions/).
 
 ## Frequently Asked Questions
 
-If you are unsure what Theia is, how it compares to other technologies or how to migrate Eclipse-based tools to it, please have a look at [resource section](../../resources/).
+If you are unsure what Theia is, how it compares to other technologies or how to migrate Eclipse-based tools to it, please have a look at [resource section](/resources/).
 
 
 ## Need Help?
 
-Theia is an open community, and we are glad to help you. You can ask questions using our [public community forum](https://github.com/eclipse-theia/theia/discussions), you can [report bugs and feature requests](https://github.com/eclipse-theia/theia/issues/new/choose), and you can get [professional support, consulting and implementation services](../../support/) for building products based on Theia.
+Theia is an open community, and we are glad to help you. You can ask questions using our [public community forum](https://github.com/eclipse-theia/theia/discussions), you can [report bugs and feature requests](https://github.com/eclipse-theia/theia/issues/new/choose), and you can get [professional support, consulting and implementation services](/support/) for building products based on Theia.

--- a/src/docs/json_rpc.md
+++ b/src/docs/json_rpc.md
@@ -90,7 +90,7 @@ an when this contribution is initialized it creates a websocket channel for all 
 To save resources the hood all `MessagingContributions` are routed over one
 websocket connection (multiplexing).
 
-To dig more into ContributionProvider see this [section](../services_and_contributions#contribution-providers).
+To dig more into ContributionProvider see this [section](/docs/services_and_contributions#contribution-providers).
 
 So now:
 
@@ -221,7 +221,7 @@ Here we're creating a watcher, this is used to get notified about events
 from the backend by using the `taskWatcher`'s client
 (`taskWatcher.getTaskClient()`)
 
-See more information about how events work in theia [here](../events#events).
+See more information about how events work in theia [here](/docs/events#events).
 
 ``` typescript
         return connection.createProxy<TaskServer>(taskPath, taskWatcher.getTaskClient());

--- a/src/docs/label_provider.md
+++ b/src/docs/label_provider.md
@@ -12,7 +12,7 @@ In this article we will describe how to customize the label and icon of a custom
 
 <img src="../../custom-label-provider.png" alt="A custom label provider" style="max-width: 525px">
 
-If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](../services_and_contributions/).
+If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](/docs/services_and_contributions/).
 
 All the following code examples are from the [Theia extension generator](https://github.com/eclipse-theia/generator-theia-extension). You can get the same code set-up by installing the generator, selecting the “Label Provider” example (see [here](https://github.com/eclipse-theia/generator-theia-extension)) and choosing “labelProvider” as the name.
 
@@ -59,7 +59,7 @@ getName(fileStatNode: FileStatNode): string {
 }
 ```
 
-To make our `LabelProviderContribution` accessible to Theia, we need to bind the custom `LabelProviderLabelProviderContribution` to the respective contribution symbol `LabelProviderContribution`. This is done in the `labelprovider-frontend-module`, for more details see [Services and Contributions](../services_and_contributions/).
+To make our `LabelProviderContribution` accessible to Theia, we need to bind the custom `LabelProviderLabelProviderContribution` to the respective contribution symbol `LabelProviderContribution`. This is done in the `labelprovider-frontend-module`, for more details see [Services and Contributions](/docs/services_and_contributions/).
 
 **labelprovider-frontend-module.ts**
 

--- a/src/docs/language_support.md
+++ b/src/docs/language_support.md
@@ -6,4 +6,4 @@ title: Language Support
 
 Theia uses standard technologies for adding language support to custom Theia-based products. By integrating the Monaco Code Editor, Theia supports the language server protocol (LSP) as well as TextMate.
 
-We recommend you use VS Code Extensions which the Theia Framework [supports](../authoring_vscode_extensions) in order to add support for an existing or a custom language. Please refer to the [VS Code Language Support](https://code.visualstudio.com/docs/languages/overview) documentation for additional details.
+We recommend you use VS Code Extensions which the Theia Framework [supports](/docs/authoring_vscode_extensions) in order to add support for an existing or a custom language. Please refer to the [VS Code Language Support](https://code.visualstudio.com/docs/languages/overview) documentation for additional details.

--- a/src/docs/services_and_contributions.md
+++ b/src/docs/services_and_contributions.md
@@ -4,9 +4,9 @@ title: Services and Contributions
 
 # Services and Contributions
 
-In this section we describe how [Theia extensions](../extensions#theia-extensions) can use services provided by the platform and by other extensions. Furthermore, we describe how extensions can contribute to the Theia workbench via contribution points.
+In this section we describe how [Theia extensions](/docs/extensions#theia-extensions) can use services provided by the platform and by other extensions. Furthermore, we describe how extensions can contribute to the Theia workbench via contribution points.
 
-A **service** is an object that provides functionality to its consumers. The contract between a service and its consumers is described by an interface. Any implementation of a service must implement that interface according to the interface documentation. Any extension in Theia can provide and/or consume services. The extensions provided by the Theia platform provide a set of default services, e.g. the [`MessageService`](../message_service/). However, you can provide and consume your own custom services, too.
+A **service** is an object that provides functionality to its consumers. The contract between a service and its consumers is described by an interface. Any implementation of a service must implement that interface according to the interface documentation. Any extension in Theia can provide and/or consume services. The extensions provided by the Theia platform provide a set of default services, e.g. the [`MessageService`](/docs/message_service/). However, you can provide and consume your own custom services, too.
 
 **Contribution points** define hooks, which allow extending something. Contribution points are defined by an interface that the contributor is expected to implement, e.g. a `CommandContribution`. The extension defining the contribution point will then pick up the contribution, e.g. adding the contributed command to the Theia workbench.
 
@@ -80,7 +80,7 @@ export default new ContainerModule(bind => {
 });
 ```
 
-Please see [Commands/Menus/Keybindings](../commands_keybindings/) for a simple example for the usage of services and contribution points.
+Please see [Commands/Menus/Keybindings](/docs/commands_keybindings/) for a simple example for the usage of services and contribution points.
 
 ## Defining Contribution-Points
 

--- a/src/docs/tasks.md
+++ b/src/docs/tasks.md
@@ -37,7 +37,7 @@ Finally, we will contribute a custom task runner that executes our provided task
 
 Task providers and task resolvers are contributed via an implementation of `TaskContribution`.
 Like all contributions, it must be bound in the respective front end module as shown below.
-If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](../services_and_contributions/).
+If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](/docs/services_and_contributions/).
 
 ``` typescript
 export default new ContainerModule(bind => {

--- a/src/docs/tips.md
+++ b/src/docs/tips.md
@@ -8,7 +8,7 @@ In this section we'll outline some advanced hints and tips to get the most out o
 
 ## Providing custom API to VS Code extensions in Eclipse Theia
 
-Theia allows running VS Code extension by providing a compatible API (see [this overview](../extensions/) for details).
+Theia allows running VS Code extension by providing a compatible API (see [this overview](/docs/extensions/) for details).
 It is possible to extend this API to allow VS Code extensions running in Theia to access additional functionality compared to when they run within VS Code.
 This allows you to provide a feature as a VS Code extension targeting VS Code and Theia. However, when running in Theia, the feature can be enhanced by using custom API only available in Theia.
 

--- a/src/docs/toolbar.md
+++ b/src/docs/toolbar.md
@@ -4,9 +4,9 @@ title: Dynamic Toolbar
 
 # Dynamic Toolbar
 
-Eclipse Theia provides an optional and fully dynamic toolbar to be included in your custom IDE or tool. Please also see [the documentation of the toolbar from a user point of view](../user_toolbar).
+Eclipse Theia provides an optional and fully dynamic toolbar to be included in your custom IDE or tool. Please also see [the documentation of the toolbar from a user point of view](/docs/user_toolbar).
 
-To enable the toolbar, simply include the Theia extension "@theia/toolbar" into your Theia-based product (also see [the documentation on composing Theia applications](../composing_applications/)).
+To enable the toolbar, simply include the Theia extension "@theia/toolbar" into your Theia-based product (also see [the documentation on composing Theia applications](/docs/composing_applications/)).
 
 The Theia toolbar defines some default commands that are displayed even before the user can configure the toolbar to their preferences. These defaults are defined in a `ToolbarDefaultsFactory`. See [here](https://github.com/eclipse-theia/theia/blob/master/packages/toolbar/src/browser/toolbar-defaults.ts) for the default `ToolbarDefaultsFactory` that is shipped within the toolbar extension.
 To define your own default commands to the toolbar, create a custom implementation of `ToolbarDefaultsFactory` and rebind you own factory in your extension module (see following code example).

--- a/src/docs/user_getting_started.md
+++ b/src/docs/user_getting_started.md
@@ -5,8 +5,8 @@ title: Using Theia As An End User
 # Using the "Theia IDE" as an End User
 
 The Theia IDE is a modern and open IDE for cloud and desktop. The Theia IDE is based on the Theia platform.
-- [Learn more about the Theia IDE](../../#theiaide)
-- [Download the Theia IDE](../../#theiaidedownload)
+- [Learn more about the Theia IDE](/#theiaide)
+- [Download the Theia IDE](/#theiaidedownload)
 - [Try the Theia IDE online](https://try.theia-cloud.io/)
 - [Run the Theia IDE with Docker](https://github.com/eclipse-theia/theia-blueprint?tab=readme-ov-file#docker-build)
 
@@ -16,7 +16,7 @@ This section is about using the Theia IDE from an end user point of view. Please
 
 The Theia IDE features and usability concept is heavily influences by VS Code. Therefore, for many use cases, we refer to the VS Code documentation. We still provide some selected documentation about use cases which are differing or not supported in VS Code:
 
-- [Install VS Code extensions](../user_install_vscode_extensions/)
-- [Using the dynamic Toolbar](../user_toolbar/)
+- [Install VS Code extensions](/docs/user_install_vscode_extensions/)
+- [Using the dynamic Toolbar](/docs/user_toolbar/)
 
-Please note that you can also [use the Theia IDE as a basis to create your own custom product](../blueprint_documentation/).
+Please note that you can also [use the Theia IDE as a basis to create your own custom product](/docs/blueprint_documentation/).

--- a/src/docs/user_install_vscode_extensions.md
+++ b/src/docs/user_install_vscode_extensions.md
@@ -6,7 +6,7 @@ title: Installing VS Code Extensions in Theia
 
 You can install VS Code extensions into Theia-based products via the [Open VSX Registry](https://open-vsx.org/), aka “Theia Marketplace” or “Theia Extension Registry”.
 
-*Note: To be able to install extensions, the creator of your Theia-based tool needs to have enabled this option. The following documentation is based on the Theia IDE, a standard product based on Theia. This might slightly differ from the Theia-based product you are using, please contact the provider of your tool if there are uncertainties and also see [here](../user_getting_started/). For tool creators, please see the end of this document.*
+*Note: To be able to install extensions, the creator of your Theia-based tool needs to have enabled this option. The following documentation is based on the Theia IDE, a standard product based on Theia. This might slightly differ from the Theia-based product you are using, please contact the provider of your tool if there are uncertainties and also see [here](/docs/user_getting_started/). For tool creators, please see the end of this document.*
 
 To install new extensions into the Theia IDE, please open the Extensions View via the Menu "View => Extensions" or via the command “Toggle Extensions View”.
 
@@ -30,4 +30,4 @@ For details about the compatibility of Theia for VS Code extensions can be found
 
 If you are missing a specific VS Code extension or if you have issues with using a VS Code extension in Theia, please report this to the creator of your Theia-based Tool. If you are using the Theia IDE or a variant of it, please report your issues [here](https://github.com/eclipse-theia/theia/issues/new?assignees=&labels=&template=bug_report.md).
 
-For adopters: If you are building a Theia-based product, please have a look at our overview about [extensions and plugins](../extensions/) as well as at the [documentation on authoring VS Code extensions in Theia](../authoring_vscode_extensions/).
+For adopters: If you are building a Theia-based product, please have a look at our overview about [extensions and plugins](/docs/extensions/) as well as at the [documentation on authoring VS Code extensions in Theia](/docs/authoring_vscode_extensions/).

--- a/src/docs/user_toolbar.md
+++ b/src/docs/user_toolbar.md
@@ -6,7 +6,7 @@ title: Using the dynamic Toolbar in Theia
 
 Eclipse Theia provides a dynamic toolbar allowing easy access to commonly used commands. The toolbar contains default commands and can be dynamically adapted by users based on their personal preference.
 
-*Note: To use the toolbar in Theia, the creator of your Theia-based tool needs to have enabled this option. The following documentation is based on the Theia IDE, a standard product based on Theia. This might slightly differ from the Theia-based product you are using, please contact the provider of your tool if there are uncertainties and also see [here](../user_getting_started/). For tool creators, please see the [toolbar adopter documentation](../toolbar/).*
+*Note: To use the toolbar in Theia, the creator of your Theia-based tool needs to have enabled this option. The following documentation is based on the Theia IDE, a standard product based on Theia. This might slightly differ from the Theia-based product you are using, please contact the provider of your tool if there are uncertainties and also see [here](/docs/user_getting_started/). For tool creators, please see the [toolbar adopter documentation](/docs/toolbar/).*
 
 As a user, you can control the default visibility of the Theia toolbar using the setting "Show Toolbar" (see screenshot below). Additionally, you can toggle the toolbar using "ALT+T" or via right-click on the toolbar => "Toggle Toolbar".
 

--- a/src/docs/widgets.md
+++ b/src/docs/widgets.md
@@ -16,7 +16,7 @@ In a nutshell, a widget is a frame to embed some custom (HTML-based) UI into the
 
 In this article we will describe how to contribute a custom widget to the Theia workbench. We will focus on a simple view (in contrast to an editor) and use React to implement the UI.
 
-If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](../services_and_contributions/).
+If you are not yet familiar with contribution points in Theia or the use of dependency injection, please consider this guide on [Services and Contributions](/docs/services_and_contributions/).
 
 If you would like to have a look at the example code, please use the [Theia extension generator](https://github.com/eclipse-theia/generator-theia-extension). Install the generator, select the “Widget” example and enter “MyWidget” as a name for the extension.
 


### PR DESCRIPTION
On hard reload the URL ending with `xyz/` sometimes becomes `xyz`, which then breaks all relative internal  links. With this change, we are adding `gatsby-plugin-catch-links` to ensure internal links work either way. Also we update the readme to reflect where the website is now hosted.