### PR TITLE
Add sepecific meta data for IDE page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
     pathPrefix: process.env.PATH_PREFIX,
     siteMetadata: {
-        title: 'Theia - Cloud and Desktop IDE Platform',
-        description: "Theia is an open-source cloud &nbsp; desktop IDE framework implemented in TypeScript."
+        title: 'Theia Platform – Open, Flexible, and Extensible Framework for Building Cloud & Desktop IDEs and Tools',
+        description: "Discover the Theia Platform, an open-source framework for building custom and tailored cloud and desktop IDEs and tools using modern web technologies without forking. Fully extensible and vendor-neutral, Theia enables the development of tailored, white-labeled, and domain-specific tools, supporting Language Server Protocol (LSP), VS Code extensions, and AI integration."
     },
     plugins: [
         'gatsby-plugin-emotion',

--- a/src/layouts/basehead.js
+++ b/src/layouts/basehead.js
@@ -1,26 +1,29 @@
-import React from 'react'
-import useSiteMetadata from '../hooks/use-site-metadata'
-import AppleTouchIcon from '../resources/apple-touch-icon.png'
-import Favicon from '../resources/theia-favicon.svg'
-import Favicon196 from '../resources/theia-favicon-196x196.png'
+import React from 'react';
+import useSiteMetadata from '../hooks/use-site-metadata';
+import AppleTouchIcon from '../resources/apple-touch-icon.png';
+import Favicon from '../resources/theia-favicon.svg';
+import Favicon196 from '../resources/theia-favicon-196x196.png';
 
-const BaseHead = ({ canonical }) => {
-    const { title, description } = useSiteMetadata()
+const BaseHead = ({ canonical, title: customTitle, description: customDescription }) => {
+    const { title: defaultTitle, description: defaultDescription } = useSiteMetadata();
+    const pageTitle = customTitle || defaultTitle;
+    const pageDescription = customDescription || defaultDescription;
+
     return (
-      <>
-        <html lang="en" />
-        <title>{title}</title>
-        <meta name="description" content={description} />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#FFFFFF" />
-        {canonical && <link rel="canonical" href={`https://theia-ide.org${canonical}`} />}
-        <link rel="apple-touch-icon" type="image/png" href={AppleTouchIcon} sizes="180x180" />
-        <link rel="icon" type="image/png" href={Favicon196} sizes="196x196" />
-        <link rel="icon" type="image/svg+xml" href={Favicon} sizes="any" />
-        <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro&display=swap" rel="stylesheet" />
-        <link href="https://fonts.googleapis.com/css?family=Montserrat:400,500&display=swap" rel="stylesheet" />
-      </>
-    )
-}
+        <>
+            <html lang="en" />
+            <title>{pageTitle}</title>
+            <meta name="description" content={pageDescription} />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <meta name="theme-color" content="#FFFFFF" />
+            {canonical && <link rel="canonical" href={`https://theia-ide.org${canonical}`} />}
+            <link rel="apple-touch-icon" type="image/png" href={AppleTouchIcon} sizes="180x180" />
+            <link rel="icon" type="image/png" href={Favicon196} sizes="196x196" />
+            <link rel="icon" type="image/svg+xml" href={Favicon} sizes="any" />
+            <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro&display=swap" rel="stylesheet" />
+            <link href="https://fonts.googleapis.com/css?family=Montserrat:400,500&display=swap" rel="stylesheet" />
+        </>
+    );
+};
 
-export default BaseHead
+export default BaseHead;

--- a/src/layouts/headwithIDEschema.js
+++ b/src/layouts/headwithIDEschema.js
@@ -1,55 +1,55 @@
-import React from 'react'
-import BaseHead from './basehead'
+import React from 'react';
+import BaseHead from './basehead';
 
-const HeadWithIDESchema = ({ canonical }) => (
-  <>
-    <BaseHead canonical={canonical} />
-    {/* JSON-LD for Theia IDE */}
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify({
-          "@context": "https://schema.org",
-          "@type": "SoftwareApplication",
-          "name": "Theia IDE",
-          "url": "https://theia-ide.org/#theiaide",
-          "image": "https://theia-ide.org/static/TheiaIDE.png",
-          "description": "Theia IDE is a modern, open-source, and flexible development environment (IDE) for developers on desktop and browser, featuring advanced AI-powered capabilities with full control over AI interactions.",
-          "operatingSystem": "Linux, macOS, Windows",
-          "applicationCategory": "DeveloperApplication",
-          "applicationSubCategory": "IntegratedDevelopmentEnvironment",
-          "softwareVersion": "1.55.0",
-          "softwareRequirements": "Compatible with VS Code extensions",
-          "author": {
-            "@type": "Organization",
-            "name": "Eclipse Foundation",
-            "url": "https://www.eclipse.org/"
-          },
-          "publisher": {
-            "@type": "Organization",
-            "name": "Eclipse Foundation",
-            "url": "https://www.eclipse.org/"
-          },
-          "releaseNotes": "https://eclipsesource.com/blogs/2024/11/07/eclipse-theia-1-54-release-news-and-noteworthy/",
-          "keywords": [
-            "open-source IDE",
-            "development environment",
-            "AI-powered IDE",
-            "VS Code extensions",
-            "VS Code alternative"
-          ],
-          "license": "Eclipse Public License 2.0",
-          "featureList": [
-            "AI-powered",
-            "Open-source",
-            "Compatible with VS Code extensions",
-            "Cross-platform support",
-            "Runs in browser and desktop environments"
-          ]
-        })
-      }}
-    />
-  </>
-)
+const HeadWithIDESchema = ({ canonical, title, description }) => (
+    <>
+        <BaseHead canonical={canonical} title={title} description={description} />
+        {/* JSON-LD for Theia IDE */}
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify({
+                    "@context": "https://schema.org",
+                    "@type": "SoftwareApplication",
+                    "name": "Theia IDE",
+                    "url": "https://theia-ide.org/#theiaide",
+                    "image": "https://theia-ide.org/static/TheiaIDE.png",
+                    "description": "Theia IDE is a modern, open-source, and flexible development environment (IDE) for developers on desktop and browser, featuring advanced AI-powered capabilities with full control over AI interactions.",
+                    "operatingSystem": "Linux, macOS, Windows",
+                    "applicationCategory": "DeveloperApplication",
+                    "applicationSubCategory": "IntegratedDevelopmentEnvironment",
+                    "softwareVersion": "1.55.0",
+                    "softwareRequirements": "Compatible with VS Code extensions",
+                    "author": {
+                        "@type": "Organization",
+                        "name": "Eclipse Foundation",
+                        "url": "https://www.eclipse.org/"
+                    },
+                    "publisher": {
+                        "@type": "Organization",
+                        "name": "Eclipse Foundation",
+                        "url": "https://www.eclipse.org/"
+                    },
+                    "releaseNotes": "https://eclipsesource.com/blogs/2024/11/07/eclipse-theia-1-54-release-news-and-noteworthy/",
+                    "keywords": [
+                        "open-source IDE",
+                        "development environment",
+                        "AI-powered IDE",
+                        "VS Code extensions",
+                        "VS Code alternative"
+                    ],
+                    "license": "Eclipse Public License 2.0",
+                    "featureList": [
+                        "AI-powered",
+                        "Open-source",
+                        "Compatible with VS Code extensions",
+                        "Cross-platform support",
+                        "Runs in browser and desktop environments"
+                    ]
+                })
+            }}
+        />
+    </>
+);
 
-export default HeadWithIDESchema
+export default HeadWithIDESchema;

--- a/src/layouts/headwithPlatformschema.js
+++ b/src/layouts/headwithPlatformschema.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import BaseHead from './basehead'
 
-const HeadWithPlatformSchema = ({ canonical }) => (
+const HeadWithPlatformSchema = ({ canonical, title, description }) => (
   <>
-    <BaseHead canonical={canonical} />
+    <BaseHead canonical={canonical} title={title} description={description} />
     {/* JSON-LD for Theia Platform */}
     <script
       type="application/ld+json"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,7 +10,13 @@ import TheiaIDEExtensible from '../components/index/TheiaIDEExtensible';
 import Footer from '../components/Footer';
 import HeadWithIDESchema from '../layouts/headwithIDEschema';
 
-export const Head = HeadWithIDESchema
+export const Head = () => (
+    <HeadWithIDESchema
+        canonical="/"
+        title="Theia IDE – Open-Source Cloud and Desktop IDE"
+        description="Theia IDE is a modern, open-source development environment that runs on desktop and in the cloud. Not a VS Code fork, Theia supports the Language Server Protocol (LSP), is fully compatible with VS Code extensions, and features advanced AI support — all while keeping full control of your data. Explore the open and flexible alternative to VS Code today!"
+    />
+);
 
 export default ({ pageContext }) => {
     return (


### PR DESCRIPTION
fixed #682

All other pages show the platform meta data for now.