### PR TITLE
Update release of GDB Adapter

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -151,7 +151,7 @@ const communityReleases = [
                 url: 'https://projects.eclipse.org/projects/ecd.cdt-cloud',
                 version: '0.0.108',
                 modules: [
-                    { modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode/0.0.108' },
+                    { modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode/1.0.4' },
                     { modulename: 'cdt-gdb-adapter', url: 'https://www.npmjs.com/package/cdt-gdb-adapter/v/1.0.3' }
                 ]
             },

--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -149,7 +149,7 @@ const communityReleases = [
             {
                 title: 'Eclipse CDT Cloud Debug Adapter',
                 url: 'https://projects.eclipse.org/projects/ecd.cdt-cloud',
-                version: '0.0.108',
+                version: '1.0.4',
                 modules: [
                     { modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode/1.0.4' },
                     { modulename: 'cdt-gdb-adapter', url: 'https://www.npmjs.com/package/cdt-gdb-adapter/v/1.0.3' }


### PR DESCRIPTION
This release was correct at the time of writing, because I didn't realize that cdt-gdb-vscode was not updating on openvsx. This has since been resolved (see https://github.com/eclipse-cdt-cloud/cdt-gdb-vscode/issues/125#issuecomment-2544032355)