### PR TITLE
Correct Blueprint redirect link

### DIFF
--- a/src/docs/blueprint_download.md
+++ b/src/docs/blueprint_download.md
@@ -4,4 +4,4 @@ title: Eclipse Theia Blueprint
 
 # Eclipse Theia Blueprint
 
-Eclipse Theia Blueprint has been rebranded to "Theia IDE" and has moved to <a href="../#theiaide">this page</a>.
+Eclipse Theia Blueprint has been rebranded to "Theia IDE" and has moved to [this page](/#theiaide).


### PR DESCRIPTION
The Theia Blueprint project has been renamed/replaced by Theia IDE. The page dedicated to Blueprint now only provides a link to redirect visitors to the information about Theia IDE.

Previously that link lead to the documentation home page. Although that page does contain a mention (of sorts) of the IDE, it is clear that it is not the intended target of the link because the link contains the `theiaide` fragment, but there is no anchor with that ID on the documentation home page. There is an anchor with that ID on the website home page, and it is that section of the website that the link was intended to target.