### PR TITLE
Update compatible technologies with EMF.cloud modules for CR 1.61.x

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -132,11 +132,13 @@ const communityReleases = [
                 version: 'TBD',
                 modules: []
             },
-            {
+           {
                 title: 'Eclipse EMF cloud',
                 url: 'https://www.eclipse.dev/emfcloud/',
-                version: 'TBD',
-                modules: []
+                version: '0.8.2',
+                modules: [
+                    { modulename: '@eclipse-emfcloud/jsonforms-property-view', url: 'https://www.npmjs.com/package/@eclipse-emfcloud/jsonforms-property-view/v/0.8.2' }
+                ]
             },
             {
                 title: 'Eclipse Sprotty',


### PR DESCRIPTION
Add `@eclipse-emfcloud/jsonforms-property-view` module version to compatible technologies section