### PR TITLE
Update trace viewer info: TBD for Theia 1.64.x

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -164,8 +164,8 @@ const communityReleases = [
             {
                 title: 'Trace Viewer Extension for Theia Applications',
                 url: 'https://github.com/eclipse-cdt-cloud/theia-trace-extension',
-                version: '0.9.1',
-                modules: [{ modulename: 'theia-traceviewer', url: 'https://www.npmjs.com/package/theia-traceviewer/v/0.9.1' }]
+                version: 'TBD',
+                modules: []
             }
         ]
     },


### PR DESCRIPTION
This PR reverts the applicable trace viewer extension for Theia 1.64.x to "TBD". 

Unfortunately, the theia traceviewer extension v0.9.1 is confirmed to not be compatible with Theia 1.64.1. It will need to be updated, but we have no ETA right now.