### PR TITLE
Make H3 in Docs identifyable

### DIFF
--- a/src/layouts/docs-layout.js
+++ b/src/layouts/docs-layout.js
@@ -59,12 +59,17 @@ const DocContainer = styled.div`
     }
 
     h1 {
-        margin-bottom: 3rem;
+        margin-bottom: 2.5rem;
     }
 
     h2 {
-        margin: 2.5rem 0;
-        font-size: 2.6rem;
+        margin: 2rem 0;
+        font-size: 2.5rem;
+    }
+
+    h3 {
+        margin: 1.5rem 0;
+        font-size: 2rem;
     }
 
     p {


### PR DESCRIPTION
The current H3 layout is very annoying, it is hard to identify it as a heading