### PR TITLE
update links to Theia API documentation

### DIFF
--- a/src/docs/commands_keybindings.md
+++ b/src/docs/commands_keybindings.md
@@ -62,7 +62,7 @@ export default new ContainerModule(bind => {
 });
 ```
 
-The `CommandRegistry` used to register our contributed command above, also provides an API to interact with commands. As an example, you can programmatically execute commands, you can browse through all registered commands or you can access a list of recently executed commands. Please refer to the [TypeDoc for the CommandRegistry](https://eclipse-theia.github.io/theia/docs/next/classes/core.commandregistry-1.html) for more details. To use the `CommandRegistry` outside of a contribution, you can access it via dependency injection.
+The `CommandRegistry` used to register our contributed command above, also provides an API to interact with commands. As an example, you can programmatically execute commands, you can browse through all registered commands or you can access a list of recently executed commands. Please refer to the [TypeDoc for the CommandRegistry](https://eclipse-theia.github.io/theia/docs/next/classes/_theia_core.common_command.CommandRegistry.html) for more details. To use the `CommandRegistry` outside of a contribution, you can access it via dependency injection.
 
 In the following sections, we describe how to bind commands to menu items and keybindings.
 
@@ -74,7 +74,7 @@ All the following code examples are from the [Theia extension generator](https:/
 
 All menu items of a Theia application are managed in the `MenuModelRegistry`. To contribute menu items to the registry, modules must implement the ´MenuContribution´ interface (see code example below).
 
-The registration of the command can be done in the function `registerMenus`, which will be called by the Theia framework. The function provides the `MenuModelRegistry` as a parameter. On this registry we can call `registerMenuAction`. It expects a `MenuPath` and a `MenuAction`. The `MenuPath` specifies the menu (and submenu) to place the menu item into. Please see [here for the paths of some common menus](https://eclipse-theia.github.io/theia/docs/next/modules/core.CommonMenus-1.html).
+The registration of the command can be done in the function `registerMenus`, which will be called by the Theia framework. The function provides the `MenuModelRegistry` as a parameter. On this registry we can call `registerMenuAction`. It expects a `MenuPath` and a `MenuAction`. The `MenuPath` specifies the menu (and submenu) to place the menu item into. Please see [here for the paths of some common menus](https://eclipse-theia.github.io/theia/docs/next/modules/_theia_core.browser_common-frontend-contribution.CommonMenus.html).
 
 The `MenuAction` consists of a command id, specifying which command to trigger, and an optional label, specifying the label of the menu item.
 
@@ -133,7 +133,7 @@ export class HelloworldKeybindingContribution implements KeybindingContribution 
 }
 ```
 
-The syntax for the “when” clause follows the [VS Code terminology](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts). Modifiers are platform independent, so [`Modifier.M1`](https://eclipse-theia.github.io/theia/docs/next/enums/core.keymodifier-2.html#ctrlcmd) is Command on OS X and CTRL on Windows/Linux. Key string constants can be viewed in [`Key` documentation](https://eclipse-theia.github.io/theia/docs/next/enums/core.KeyModifier-4.html).
+The syntax for the “when” clause follows the [VS Code terminology](https://code.visualstudio.com/docs/getstarted/keybindings#_when-clause-contexts). Modifiers are platform independent, so [`Modifier.M1`](https://eclipse-theia.github.io/theia/docs/next/enums/_theia_core.common_keys.KeyModifier.html#ctrlcmd) is Command on OS X and CTRL on Windows/Linux. Key string constants can be viewed in [`Key` documentation](https://eclipse-theia.github.io/theia/docs/next/enums/_theia_core.common_keys.KeyModifier.html).
 
 Just as you needed to bind the contributions before, keybinding contributions also need to be bound to the symbol `KeybindingContribution` to make them accessible for Theia.
 

--- a/src/docs/label_provider.md
+++ b/src/docs/label_provider.md
@@ -4,7 +4,7 @@ title: Label Provider
 
 # Label Provider
 
-A label provider in Eclipse Theia is responsible for the way elements/nodes are presented in the UI. The label provider determines the icon and the text for elements displayed in trees, lists or other locations such as view headers. A good example is the file explorer: file and directory nodes retrieve their icon and text from the label provider. Another example for the usage of a label provider is the header of an open editor. Please also see the [LabelProvider TypeDoc](https://eclipse-theia.github.io/theia/docs/next/classes/core.labelprovider-1.html).
+A label provider in Eclipse Theia is responsible for the way elements/nodes are presented in the UI. The label provider determines the icon and the text for elements displayed in trees, lists or other locations such as view headers. A good example is the file explorer: file and directory nodes retrieve their icon and text from the label provider. Another example for the usage of a label provider is the header of an open editor. Please also see the [LabelProvider TypeDoc](https://eclipse-theia.github.io/theia/docs/next/classes/_theia_core.browser_label-provider.LabelProvider.html).
 
 The default label provider in Theia browses registered label provider contributions to determine the best fitting one for an element/node. The label provider will delegate the calls for a specific node to the contribution which can best handle the element. Eclipse Theia provides default label provider contributions for common types, e.g. for files. By providing your own label provider contributions, you can extend or adapt the look of specific nodes, based on specific criteria.
 
@@ -45,7 +45,7 @@ canHandle(element: object): number {
 }
 ```
 
-Once the label provider contribution is registered for your custom file extension, you can optionally implement `getName`, `getIcon` and `getLongName`. These receive a URI as a parameter and return a custom icon and a custom name for the respective file. Icon and name are used in the file view of Theia. The long name (not customized in the example) is shown as a tooltip when you hover over the file in an opened editor tab. For more details, see the [`LabelProviderContribution` TypeDoc](https://eclipse-theia.github.io/theia/docs/next/interfaces/core.labelprovidercontribution-1.html)
+Once the label provider contribution is registered for your custom file extension, you can optionally implement `getName`, `getIcon` and `getLongName`. These receive a URI as a parameter and return a custom icon and a custom name for the respective file. Icon and name are used in the file view of Theia. The long name (not customized in the example) is shown as a tooltip when you hover over the file in an opened editor tab. For more details, see the [`LabelProviderContribution` TypeDoc](https://eclipse-theia.github.io/theia/docs/next/interfaces/_theia_core.browser_label-provider.LabelProviderContribution.html)
 
 **labelprovider-contribution.ts**
 

--- a/src/docs/menu.js
+++ b/src/docs/menu.js
@@ -33,7 +33,7 @@ export const MENU = [
         'Project Goals',
         'project_goals'
     ),
-        M(
+    M(
         'Theia FAQ',
         'faq'
     ),
@@ -94,6 +94,10 @@ export const MENU = [
     M(
         'Consuming Theia fixes without upgrading',
         'consume_theia_fixes_master'
+    ),
+    M(
+        'Theia API Documentation',
+        'theia_api_documentation'
     ),
     {
         title: 'Platform Concepts & APIs'

--- a/src/docs/message_service.md
+++ b/src/docs/message_service.md
@@ -56,7 +56,7 @@ When the user selects “Say Hello again”, another toast notification will be 
 
 ## Progress Reporting
 
-The message service also allows you to report progress on an ongoing operation. You can incrementally update a progress bar and the message while the toast notification remains visible until the operation is done. The following example opens a progress bar and updates the status three times before it is completed. Please see the [TypeDoc of `MessageService`](https://eclipse-theia.github.io/theia/docs/next/classes/core.messageservice-1.html#showprogress) for more detailed information.
+The message service also allows you to report progress on an ongoing operation. You can incrementally update a progress bar and the message while the toast notification remains visible until the operation is done. The following example opens a progress bar and updates the status three times before it is completed. Please see the [TypeDoc of `MessageService`](https://eclipse-theia.github.io/theia/docs/next/classes/_theia_core.common_message-service.MessageService.html#showprogress) for more detailed information.
 
 ```typescript
 this.messageService

--- a/src/docs/theia_api_documentation.md
+++ b/src/docs/theia_api_documentation.md
@@ -1,0 +1,7 @@
+---
+title: Theia API documentation
+---
+
+# Theia API documentation
+
+For detailed Theia API information, visit the public [Theia API Documentation](https://eclipse-theia.github.io/theia/docs/next/index.html).

--- a/src/docs/widgets.md
+++ b/src/docs/widgets.md
@@ -132,7 +132,7 @@ Widget contributions allow you to wire a widget into the Theia workbench, more p
 
 * `widgetID`: The ID of the widget, used to open it via the widget manager
 * `widgetName`: The name which is displayed in the view menu. Usually the same name as used for the widget tab.
-* `defaultWidgetOptions`: Option to influence where the widget will be displayed on opening, e.g. in the left area of the workbench. See [the typedoc](https://eclipse-theia.github.io/theia/docs/next/interfaces/core.core.WidgetOptions.html) for more information.
+* `defaultWidgetOptions`: Option to influence where the widget will be displayed on opening, e.g. in the left area of the workbench. See [the typedoc](https://eclipse-theia.github.io/theia/docs/next/interfaces/_theia_core.browser_shell_application-shell.ApplicationShell.WidgetOptions.html) for more information.
 * `toggleCommandId`: The command that opens the view. You can use the pre implemented `openView` function provided by the super class.
 Besides specifying these base parameters, you need to register the command to open the view. The base class implements the respective command contribution interface, so you just need to implement `registerCommands` to do so (see below).
 


### PR DESCRIPTION
Since we had to update our typedoc generated API docs, the links have changed.
Also added a link to the API docs, please feel free to suggest another location if you can think of a better one.

Current API documentation: https://eclipse-theia.github.io/theia/docs/next/index.html
