### PR TITLE
Update pr-preview-action to v1.8.1 for workflow_run support

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -47,7 +47,7 @@ jobs:
           path: ./public
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
-      - uses: rossjrw/pr-preview-action@f31d5aa7b364955ea86228b9dcd346dc3f29c408 #v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #v1.8.1
         id: deployment
         with:
           source-dir: ./public

--- a/.github/workflows/preview-remove.yml
+++ b/.github/workflows/preview-remove.yml
@@ -30,7 +30,7 @@ jobs:
       # checks out base branch only - never PR code
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
-      - uses: rossjrw/pr-preview-action@f31d5aa7b364955ea86228b9dcd346dc3f29c408 #v1
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #v1.8.1
         id: deployment
         with:
           preview-branch: previews


### PR DESCRIPTION
The preview workflows introduced in PR #905 use workflow_run trigger, which doesn't provide github.event.number. The pr-number input parameter was added to pass the PR number, but v1.4.7 doesn't support this input.
This causes previews to deploy to the wrong path and no comment being posted. See also https://github.com/eclipse-theia/theia-website/actions/runs/21411724521/job/61650118714#step:6:1 for the warning.

Upgrade to v1.8.1 which adds the pr-number input parameter, fixing:
- Preview deployment to correct directory (pr-previews/pr-{number})
- Sticky comment posting on the PR

Note: This can't be tested before merging because workflow_run workflows always run from master, not from the PR branch. 