### PR TITLE
Fix preview comments

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -57,3 +57,14 @@ jobs:
           token: ${{ secrets.DEPLOY_PREVIEW_TOKEN }}
           pr-number: ${{ steps.pr.outputs.number }}
           action: deploy
+          # TODO
+          # Temporarily disable built-in comment since it doesn't support workflow_run
+          # Workaround until upstream fix is merged: https://github.com/rossjrw/pr-preview-action/pull/131
+          comment: false
+      - name: Leave a comment on the PR
+        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        with:
+          header: pr-preview
+          number: ${{ steps.pr.outputs.number }}
+          message: |
+            :rocket: Deployed preview to ${{ steps.deployment.outputs.deployment-url }}


### PR DESCRIPTION
**Problem**

The `pr-preview-action` doesn't forward the `pr-number` input to the `sticky-pull-request-comment` step, causing comments to be skipped in `workflow_run` contexts where `github.event.pull_request.number` is unavailable:

```
no pull request numbers given: skip step
```

See: https://github.com/eclipse-theia/theia-website/actions/runs/21430355423/job/61708044522#step:6:206

**Temporary solution for our repo:**

Work around by disabling the built-in comment and calling `sticky-pull-request-comment` directly with the PR number.

Upstream fix submitted: https://github.com/rossjrw/pr-preview-action/pull/131

Once the upstream fix is merged and released, we can simplify this by removing the workaround and re-enabling the built-in comment.

**Testing Note:**
This can't be tested before merging because workflow_run workflows always run from master, not from the PR branch.
