### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -19,12 +19,12 @@ jobs:
   build-preview:
     runs-on: ubuntu-latest
     steps:
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '20.x'
+          node-version: '24.x'
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Full history needed for git log last modified dates
       - name: Build website
@@ -36,12 +36,12 @@ jobs:
           mkdir -p ./pr-metadata
           echo "${{ github.event.number }}" > ./pr-metadata/pr-number
       - name: Upload artifact
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: "site"
           path: ./public
       - name: Upload PR metadata
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: "pr-metadata"
           path: ./pr-metadata

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       url: ${{ steps.deployment.outputs.deployment-url }}
     steps:
       - name: Download PR metadata
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: "pr-metadata"
           path: ./pr-metadata
@@ -39,9 +39,9 @@ jobs:
       # checkout required for pr-preview-action to succeed,
       # while the content will not be used
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Download the preview page
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 #v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: "site"
           path: ./public
@@ -62,7 +62,7 @@ jobs:
           # Workaround until upstream fix is merged: https://github.com/rossjrw/pr-preview-action/pull/131
           comment: false
       - name: Leave a comment on the PR
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           header: pr-preview
           number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/preview-remove.yml
+++ b/.github/workflows/preview-remove.yml
@@ -29,7 +29,7 @@ jobs:
       # checkout required for pr-preview-action to succeed,
       # checks out base branch only - never PR code
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #v1.8.1
         id: deployment
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,23 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout website sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Full history needed for git log last modified dates
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af #v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: 20.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
       - name: Configure Pages
         id: pages
-        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d #v4
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d #v6.0.0
       - name: Build website
         run: |
           npm install
           npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa #v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 #v5.0.0
         with:
           path: ./public
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e #v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 #v5.0.0


### PR DESCRIPTION
Update remaining workflow action references to resolve Node.js 20 deprecation warnings. Node.js 20 actions will be forced to run on Node.js 24 starting June 2nd, 2026.

Action version bumps:
- actions/download-artifact: v4 > v8.0.1
- actions/checkout: v4 > v6.0.2
- actions/setup-node: v4 > v6.2.0
- actions/upload-artifact: v4 > v6.0.0
- marocchino/sticky-pull-request-comment: V2.9.2 > V3.0.4
- actions/configure-pages: v4 > v6.0.0
- actions/upload-pages-artifact: v4 > v5.0.0
- actions/deploy-pages: v4 > v5.0.0

Contributed on behalf of STMicroelectronics