### PR TITLE
ci: disable persist-credentials in preview workflow checkouts

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -40,6 +40,10 @@ jobs:
       # while the content will not be used
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Prevent the GITHUB_TOKEN extraheader from overriding the deploy
+          # token used by pr-preview-action when pushing to the previews repo.
+          persist-credentials: false
       - name: Download the preview page
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/preview-remove.yml
+++ b/.github/workflows/preview-remove.yml
@@ -30,6 +30,10 @@ jobs:
       # checks out base branch only - never PR code
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Prevent the GITHUB_TOKEN extraheader from overriding the deploy
+          # token used by pr-preview-action when pushing to the previews repo.
+          persist-credentials: false
       - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 #v1.8.1
         id: deployment
         with:


### PR DESCRIPTION
- After bumping actions/checkout to v6, the remove-preview workflow failed with HTTP 403 when pushing to theia-website-previews because the push was attributed to github-actions[bot] instead of using DEPLOY_PREVIEW_TOKEN (see https://github.com/eclipse-theia/theia-website/actions/runs/25494012366)
- actions/checkout v6 leaves a GITHUB_TOKEN extraheader that the JamesIves/github-pages-deploy-action (wrapped by pr-preview-action) cannot unset, so it overrides the deploy token embedded in the remote URL
- Documented workaround: set persist-credentials: false on the checkout step so no GITHUB_TOKEN credential is persisted for the pr-preview-action push to use
- Applied to preview-deploy.yml and preview-remove.yml; preview-build.yml performs no git push and is unaffected

Contributed on behalf of STMicroelectronics