### PR TITLE
Update Theia 2026-05 Technologies Releases and add npm link

### DIFF
--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -85,9 +85,9 @@ const communityReleases = [
             {
                 title: 'Eclipse GLSP',
                 url: 'https://www.eclipse.dev/glsp/',
-                version: '2.7.0-next.10',
+                version: '2.7.0',
                 modules: [
-                    { modulename: '@eclipse-glsp/theia-integration', url: 'https://www.npmjs.com/package/@eclipse-glsp/theia-integration/v/2.7.0-next.10' }
+                    { modulename: '@eclipse-glsp/theia-integration', url: 'https://www.npmjs.com/package/@eclipse-glsp/theia-integration/v/2.7.0' }
                 ]
             },
             {

--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -79,6 +79,8 @@ const communityReleases = [
         technologiesin: 'June 4th, 2026',
         releaseanouncement: 'June 11th, 2026',
         announcementurl: '',
+        npmVersion: '1.71.2',
+        npmUrl: 'https://www.npmjs.com/package/@theia/core/v/1.71.2',
         frameworks: [
             {
                 title: 'Eclipse GLSP',
@@ -1117,13 +1119,14 @@ const Releases = () => (
         <div className='row'>
             <h1 className='heading-primary'>Community Releases</h1>
         </div>
-        {communityReleases.map(({ name, frameworks, releasedate, releasecandidatedate, technologiesin, releaseanouncement, announcementurl }, i) => {
+        {communityReleases.map(({ name, frameworks, releasedate, releasecandidatedate, technologiesin, releaseanouncement, announcementurl, npmVersion, npmUrl }, i) => {
             return (
                 <section key={i} className="category row" id="frameworks">
                     <h2 className="heading-secondary">{name}</h2>
                     <p>Community Release Candidate: <b>{releasecandidatedate}</b></p>
                     <p>Community Release Available: <b>{releasedate}</b></p>
                     <p>Compatible Technologies Listed: <b>{technologiesin}</b></p>
+                    {npmVersion && <p>Latest npm version: <b>{npmUrl ? <a href={npmUrl}>{npmVersion}</a> : npmVersion}</b></p>}
                     <p><a href={announcementurl}>Community Release Announcement</a>: <b>{releaseanouncement}</b></p>
                     <br></br>
                     <p><h3 className="heading-tertiary"><b>Compatible Technologies:</b></h3></p>

--- a/src/components/Releases.js
+++ b/src/components/Releases.js
@@ -83,44 +83,44 @@ const communityReleases = [
             {
                 title: 'Eclipse GLSP',
                 url: 'https://www.eclipse.dev/glsp/',
-                version: 'TBD',
+                version: '2.7.0-next.10',
                 modules: [
-                    { modulename: '@eclipse-glsp/theia-integration', url: 'https://www.npmjs.com/package/@eclipse-glsp/theia-integration' }
+                    { modulename: '@eclipse-glsp/theia-integration', url: 'https://www.npmjs.com/package/@eclipse-glsp/theia-integration/v/2.7.0-next.10' }
                 ]
             },
             {
                 title: 'Eclipse EMF cloud',
                 url: 'https://www.eclipse.dev/emfcloud/',
-                version: 'TBD',
+                version: '0.8.5',
                 modules: [
-                    { modulename: '@eclipse-emfcloud/jsonforms-property-view', url: 'https://www.npmjs.com/package/@eclipse-emfcloud/jsonforms-property-view' }
+                    { modulename: '@eclipse-emfcloud/jsonforms-property-view', url: 'https://www.npmjs.com/package/@eclipse-emfcloud/jsonforms-property-view/v/0.8.5' }
                 ]
             },
             {
                 title: 'Eclipse Sprotty',
                 url: 'https://www.eclipse.dev/sprotty/',
-                version: 'TBD',
+                version: '1.4.0',
                 modules: []
             },
             {
                 title: 'Eclipse CDT Cloud Debug Adapter',
                 url: 'https://projects.eclipse.org/projects/ecd.cdt-cloud',
-                version: 'TBD',
+                version: '2.8.0',
                 modules: [
-                    { modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode' },
-                    { modulename: 'cdt-gdb-adapter', url: 'https://www.npmjs.com/package/cdt-gdb-adapter' }
+                    { modulename: 'cdt-gdb-vscode', url: 'https://open-vsx.org/extension/eclipse-cdt/cdt-gdb-vscode/2.8.0' },
+                    { modulename: 'cdt-gdb-adapter', url: 'https://www.npmjs.com/package/cdt-gdb-adapter/v/1.9.0' }
                 ]
             },
             {
                 title: 'Langium',
                 url: 'https://langium.org/',
-                version: 'TBD',
+                version: '4.2.4',
                 modules: []
             },
             {
                 title: 'Trace Viewer for VSCode',
                 url: 'https://open-vsx.org/extension/eclipse-cdt/vscode-trace-extension',
-                version: 'TBD',
+                version: '0.8.0',
                 modules: []
             }
         ]


### PR DESCRIPTION
- Specify latest versions of technologies declared to be compatible with Theia 2026-05 (1.71.x)
- Add npm version metadata to community release 
   - Starting with 2026-05 community release

@ all please confirm the selected version for the technology you are involved in is, TIA!