### PR TITLE
docs: fix broken provider table in user_ai.md

### DIFF
--- a/src/docs/user_ai.md
+++ b/src/docs/user_ai.md
@@ -140,7 +140,7 @@ See the individual provider sections below for the specific environment variable
 Below is an overview of various Large Language Model (LLM) providers supported within the Theia IDE, highlighting their key features and current state.
 
 | Provider                                                   | Streaming  | Tool Calls  | Structured Output  | State        |
-|------------------------------------------------------------|:----- ----:|:-----------:|:------------------:|--------------|
+|------------------------------------------------------------|:----------:|:-----------:|:------------------:|--------------|
 | [GitHub Copilot](#github-copilot)                          |     ✅     |     ✅      |         ✅         | Public       |
 | [OpenAI Official](#openai-hosted-by-openai)                |     ✅     |     ✅      |         ✅         | Public       |
 | [OpenAI Compatible](#openai-compatible-models-eg-via-vllm) |     ✅     |     ✅      |         ✅         | Public       |


### PR DESCRIPTION
Check provider table is fixed at `docs/user_ai/#llm-providers-overview`:

- https://eclipse-theia.github.io/theia-website-previews/pr-previews/pr-962/docs/user_ai/#llm-providers-overview